### PR TITLE
Fix/scraper empty year logbook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN adduser -D appuser && chown -R appuser:appuser /app
 USER appuser
 
 EXPOSE 8501
-HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
+# HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
 ENTRYPOINT ["streamlit", "run", "main.py"]

--- a/givav/scrape.py
+++ b/givav/scrape.py
@@ -36,6 +36,8 @@ def surrounded(tag):
 
 def scrappe_logbook_byyear(session, year, club_number):
 	logbook_byyear = list()
+	current_year = str(datetime.now().year)
+
 	# get the logbook for the season of the year
 	click.echo(click.style('Year {}'.format(year), fg='blue'))
 
@@ -49,7 +51,7 @@ def scrappe_logbook_byyear(session, year, club_number):
 		rows = soup.find_all(surrounded)
 		click.echo(click.style('  Found {} rows in the HTML table'.format(len(rows)), fg='white'))
 
-		if (len(rows) > 1):
+		if (len(rows) > 1) or ((len(rows) == 1) and (year == current_year)):
 			# Found entries, decode them
 			with click.progressbar(rows, label='  Extract flight data', show_pos=True, show_eta=False, show_percent=False, width=len(rows)) as bar:
 				for row in bar:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
 	name='givav-scrape',
-	version='1.0.0',
+	version='1.0.1',
 	# py_modules=['givav-scrape'],
 	packages=find_packages(),
 	install_requires=[

--- a/sidebar.py
+++ b/sidebar.py
@@ -3,7 +3,7 @@ import pandas as pd
 import datetime
 from translations import _, get_language, TRANSLATIONS
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 def language_selector():
 	"""Add a language selector in the sidebar."""


### PR DESCRIPTION
Previously, the scraper failed to iterate through the history if the  current year's logbook was empty. Updated the navigation logic to  ensure the scraper moves to the previous year regardless of the  current year's flight count.